### PR TITLE
MI5-98 Izrada endpointa za dohvat podataka za prikaz broja transakcija po danima

### DIFF
--- a/src/main/java/foi/air/szokpt/reports/clients/TransactionClient.java
+++ b/src/main/java/foi/air/szokpt/reports/clients/TransactionClient.java
@@ -9,7 +9,6 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,9 +24,7 @@ public class TransactionClient {
         this.restTemplate = restTemplate;
     }
 
-    public List<Transaction> getTransactions(String authorizationHeader) {
-        LocalDateTime after = LocalDate.now().atStartOfDay();
-        LocalDateTime before = LocalDateTime.now();
+    public List<Transaction> getTransactions(String authorizationHeader, LocalDateTime after, LocalDateTime before) {
 
         String url = baseUrl + "/transactions" + "?after=" + after + "&before=" + before;
 

--- a/src/main/java/foi/air/szokpt/reports/controllers/ReportController.java
+++ b/src/main/java/foi/air/szokpt/reports/controllers/ReportController.java
@@ -3,6 +3,7 @@ package foi.air.szokpt.reports.controllers;
 import foi.air.szokpt.reports.dtos.responses.ApiResponse;
 import foi.air.szokpt.reports.dtos.responses.CardBrandsReportData;
 import foi.air.szokpt.reports.dtos.responses.SuccessReportData;
+import foi.air.szokpt.reports.dtos.responses.TransactionsPerDayReportData;
 import foi.air.szokpt.reports.services.ReportService;
 import foi.air.szokpt.reports.util.ApiResponseUtil;
 import foi.air.szokpt.reports.util.Authorizer;
@@ -45,7 +46,18 @@ public class ReportController {
         authorizer.verifyToken(authorizationHeader);
         CardBrandsReportData data = reportService.getCardBrandsReport(authorizationHeader);
         return ResponseEntity.status(HttpStatus.OK).body(
-                ApiResponseUtil.successWithData("Successful login", data)
+                ApiResponseUtil.successWithData("Card brands data successfully fetched.", data)
+        );
+    }
+
+    @GetMapping("/transactions-per-day")
+    public ResponseEntity<ApiResponse<TransactionsPerDayReportData>> transactionsPerDayReport(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        authorizer.verifyToken(authorizationHeader);
+        TransactionsPerDayReportData data = reportService.getTransactionsPerDayReport(authorizationHeader);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                ApiResponseUtil.successWithData("Transactions per day data successfully fetched.", data)
         );
     }
 }

--- a/src/main/java/foi/air/szokpt/reports/dtos/responses/TransactionsPerDayReportData.java
+++ b/src/main/java/foi/air/szokpt/reports/dtos/responses/TransactionsPerDayReportData.java
@@ -1,0 +1,30 @@
+package foi.air.szokpt.reports.dtos.responses;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public class TransactionsPerDayReportData {
+    private int totalTransactions;
+    private Map<LocalDateTime, Integer> transactionsPerDay;
+
+    public TransactionsPerDayReportData(int totalTransactions, Map<LocalDateTime, Integer> transactionsPerDay) {
+        this.totalTransactions = totalTransactions;
+        this.transactionsPerDay = transactionsPerDay;
+    }
+
+    public int getTotalTransactions() {
+        return totalTransactions;
+    }
+
+    public void setTotalTransactions(int totalTransactions) {
+        this.totalTransactions = totalTransactions;
+    }
+
+    public Map<LocalDateTime, Integer> getTransactionsPerDay() {
+        return transactionsPerDay;
+    }
+
+    public void setTransactionsPerDay(Map<LocalDateTime, Integer> transactionsPerDay) {
+        this.transactionsPerDay = transactionsPerDay;
+    }
+}


### PR DESCRIPTION
Na putanji /reports/transactions-per-day dohvaćaju se informacije o broju transakcija proteklih tjedan dana. Servis prvo radi validaciju jwt tokena, a zatim dohvaća podatke transakcija koje su se dogodile proših 7 dana (zadnjih 6 dana +danas). Podatke vraća na način da vrati ukupni broj transakcija u tom periodu, a zatim mapu oblika <LocalDateTime dan, Integer broj> sa semantikom, tog dana dogodilo se broj transakcija.